### PR TITLE
Recording video with audio stream bug fixed

### DIFF
--- a/VideoRecorder/SCAudioEncoder.m
+++ b/VideoRecorder/SCAudioEncoder.m
@@ -32,7 +32,7 @@
     
     if (self != nil) {
         self.outputBitRate = 128000;
-        self.outputEncodeType = kAudioFormatMPEGLayer3;
+        self.outputEncodeType = kAudioFormatMPEG4AAC;
     }
     
     return self;

--- a/VideoRecorder/SCAudioVideoRecorder.m
+++ b/VideoRecorder/SCAudioVideoRecorder.m
@@ -187,6 +187,11 @@
             }];
         } else {
             NSURL * fileUrl = self.outputFileUrl;
+            
+            if(self.assetWriter.status == AVAssetWriterStatusFailed){
+                NSLog(@"assets write failed:%@ ",self.assetWriter.error);
+                return ;
+            }
 
             if (self.assetWriter.status != AVAssetWriterStatusUnknown) {
                 [self.assetWriter finishWritingWithCompletionHandler:^ {


### PR DESCRIPTION
While using self.outputEncodeType = kAudioFormatMPEGLayer3, when [self stop] in SCAudioVideoRecorder, the status would change to AVAssetWriterStatusFailed which you didn't add the if code there and the error info is:

failed:Error Domain=AVFoundationErrorDomain Code=-11834 "Cannot Encode" UserInfo=0x1e5b5df0 {NSLocalizedDescription=Cannot Encode, NSLocalizedFailureReason=The encoder required for this media cannot be found.}

Changing the mp3 to self.outputEncodeType = kAudioFormatMPEG4AAC  works fine.

I am not sure whether the audio stream of a MP4 file can ONLY be an AAC stream, but I am sure that it certainly cannot be mp3.
