### PR TITLE
Temporary (terrible) fix for iOS example project.

### DIFF
--- a/SCAudioVideoRecorderExampleIOS/SCVideoPlayerViewController.m
+++ b/SCAudioVideoRecorderExampleIOS/SCVideoPlayerViewController.m
@@ -32,6 +32,8 @@
 {
     [super viewDidLoad];
 	
+    NSLog(@"Logging use of %@ too see if it's a linker problem", [SCVideoPlayerView class]);
+    
 	[self.videoPlayerView.player setSmoothLoopItemByUrl:self.videoUrl smoothLoopCount:10];
 
 	self.videoPlayerView.player.shouldLoop = YES;


### PR DESCRIPTION
The iOS example does not function unless there is a reference to SCVideoPlayerView actually in the code. You can thank IB for that.

This is a temporary fix, but necessary one. (Working on doing it right.)
