### PR TITLE
Fixes _currentRecordDuration reported value

### DIFF
--- a/Library/Sources/SCRecordSession.m
+++ b/Library/Sources/SCRecordSession.m
@@ -449,6 +449,7 @@ const NSString *SCRecordSessionDateKey = @"Date";
                 });
             }];
         }
+        _lastTime = _sessionStartedTime;
     } else {
         dispatch_async(dispatch_get_main_queue(), ^{
             if (completionHandler != nil) {


### PR DESCRIPTION
Fixes _currentRecordDuration reported value when segments are deleted from a SCRecorder's SCRecordSession
