### PR TITLE
Optionally dropping frames

### DIFF
--- a/Examples/Sources/SCRecorderViewController.m
+++ b/Examples/Sources/SCRecorderViewController.m
@@ -69,6 +69,8 @@
     _recorder = [SCRecorder recorder];
     _recorder.sessionPreset = AVCaptureSessionPreset1280x720;
     _recorder.maxRecordDuration = CMTimeMake(5, 1);
+    _recorder.videoConfiguration.maxFrameRate = 10;
+    _recorder.videoConfiguration.timeScale = 0.333;
     
     _recorder.delegate = self;
     _recorder.autoSetVideoOrientation = YES;

--- a/Library/Sources/SCRecordSession_Internal.h
+++ b/Library/Sources/SCRecordSession_Internal.h
@@ -23,6 +23,8 @@
     CMTime _timeOffset;
     CMTime _lastTimeVideo;
     CMTime _lastTimeAudio;
+    CMTime _lastAppendedVideo;
+    CMTime _sessionBegan;
     
     SCVideoConfiguration *_videoConfiguration;
     SCAudioConfiguration *_audioConfiguration;

--- a/Library/Sources/SCVideoConfiguration.h
+++ b/Library/Sources/SCVideoConfiguration.h
@@ -43,7 +43,7 @@
 @property (copy, nonatomic) NSString *scalingMode;
 
 /**
- The maximum framerate that this SCRecordSession should handle
+ The maximum input framerate that this SCRecordSession should handle
  If the camera appends too much frames, they will be dropped.
  If this property's value is 0, it will use the current video
  framerate from the camera.


### PR DESCRIPTION
My application needed to create a "slideshow" of three frames to be shown with one second each and those frames should be captured one second after the previous. I "achieved" it with the following: 

```
recordSession.suggestedMaxRecordDuration = CMTimeMake(299, 100)
recordSession.videoMaxFrameRate = 1
recordSession.videoTimeScale = 3
```

However, it captured 3 frames, extended their output length to 1 second, and thus, created a 3 second video with three frames of one second each, however, the recording took a fraction of a second. The frames weren't being captured with one second distance of each other. 

My solution adds the boolean property `shouldDropFrames` to `SCRecordSession`. It's default value is `YES`, so nothing needs to be changed for the default behavior to continue, however, if this property is set to `NO`, the session will drop the frames until the full length of the recording is over.

I had to customize the framework in order to achieve what I needed. I do realise this behavior may not be intended, but, nevertheless, I thought it would be interesting to submit a pull-request for your appreciation.
