### PR TITLE
Add movieFragmentInterval in order to limit buffering time on playback u...

### DIFF
--- a/Library/Sources/SCAssetExportSession.m
+++ b/Library/Sources/SCAssetExportSession.m
@@ -315,6 +315,8 @@ const NSString *SCAssetExportSessionPresetLowQuality = @"LowQuality";
 
     EnsureSuccess(error, completionHandler);
     
+    _writer.movieFragmentInterval = CMTimeMakeWithSeconds(1, 600);
+    
     _reader = [AVAssetReader assetReaderWithAsset:self.inputAsset error:&error];
     EnsureSuccess(error, completionHandler);
     

--- a/Library/Sources/SCRecordSession.m
+++ b/Library/Sources/SCRecordSession.m
@@ -299,6 +299,7 @@ NSString *SCRecordSessionCacheDirectory = @"CacheDirectory";
     
     if (theError == nil) {
         writer.shouldOptimizeForNetworkUse = YES;
+        writer.movieFragmentInterval = CMTimeMakeWithSeconds(1, 600);
         
         if (_videoInput != nil) {
             if ([writer canAddInput:_videoInput]) {


### PR DESCRIPTION
The app that I am building records a video with SCRecorder, uploads it to a server, where it is segmented into an HLS video and then plays it back. What I've noticed is that on slow Internet connections the video quite often needs to be buffered entirely before `AVPlayer` starts playback. I am able to replicate this behaviour using VLC and Safari's video player. Setting the `movieFragmentInterval` on `AVAssetWriter` when it is created to 1 second in `SCRecordSession` and `SCAssetExportSession` reduces the buffer time significantly. I think it has something to do with the MPEG headers inside the exported MP4 file.
