### PR TITLE
Fixed bug where ratioRecorded computed property was incorrectly named re...

### DIFF
--- a/Library/Sources/SCRecorder.m
+++ b/Library/Sources/SCRecorder.m
@@ -1311,7 +1311,7 @@
     return foundSupported;
 }
 
-- (CGFloat)recordedRatio {
+- (CGFloat)ratioRecorded {
     CGFloat ratio = 0;
     
     if (CMTIME_IS_VALID(_maxRecordDuration)) {


### PR DESCRIPTION
Fixed a bug where ratioRecorded computed property was incorrectly defined as recordedRatio in the implementation file. This causes ratioRecorded to always return 0

The same issue was brought up in pull request #99, however this pull request does not change the original property name.
