### PR TITLE
Crash fixed when initializing with older dictionary representations

### DIFF
--- a/Library/Sources/SCRecordSession.m
+++ b/Library/Sources/SCRecordSession.m
@@ -39,9 +39,15 @@ NSString *SCRecordSessionCacheDirectory = @"CacheDirectory";
         
         int i = 0;
         BOOL shouldRecomputeDuration = NO;
-        for (NSDictionary *recordSegment in recordSegments) {
-            NSString *filename = recordSegment[SCRecordSessionSegmentFilenameKey];
-            NSDictionary *info = recordSegment[SCRecordSessionSegmentInfoKey];
+        for (NSObject *recordSegment in recordSegments) {
+            NSString *filename = nil;
+            NSDictionary *info = nil;
+            if ([recordSegment isKindOfClass:[NSDictionary class]]) {
+                filename = ((NSDictionary *)recordSegment)[SCRecordSessionSegmentFilenameKey];
+                info = ((NSDictionary *)recordSegment)[SCRecordSessionSegmentInfoKey];
+            } else if ([recordSegment isKindOfClass:[NSString class]]) {
+                filename = (NSString *)recordSegment;
+            }
             
             NSURL *url = [SCRecordSession segmentURLForFilename:filename andDirectory:_recordSegmentsDirectory];
             


### PR DESCRIPTION
The older structure of the `dictionaryRepresentation` of an `SCRecordSession` represented the recordSegments as Strings, but the new structure is an `NSDictionary`. This was crashing our app when using the new version of `SCRecordSession` and `initWithDictionaryRepresentation`. I've added code to check and migrate the older structure to the new structure for apps that used older versions of SCRecorder.