### PR TITLE
Exposed suppress player rendering property in SCPlayer

### DIFF
--- a/Library/Sources/SCPlayer.h
+++ b/Library/Sources/SCPlayer.h
@@ -67,6 +67,11 @@
 @property (readonly, nonatomic) BOOL isPlaying;
 
 /**
+ Whether this instance displays default rendered video
+ */
+@property (assign, nonatomic) BOOL shouldSuppressPlayerRendering;
+
+/**
  The actual item duration.
  */
 @property (readonly, nonatomic) CMTime itemDuration;

--- a/Library/Sources/SCPlayer.m
+++ b/Library/Sources/SCPlayer.m
@@ -37,7 +37,7 @@ static char* ItemChanged = "CurrentItemContext";
 	self = [super init];
 	
 	if (self) {
-
+        _shouldSuppressPlayerRendering = YES;
 		[self addObserver:self forKeyPath:@"currentItem" options:NSKeyValueObservingOptionNew context:ItemChanged];
 	}
 	
@@ -202,7 +202,7 @@ static char* ItemChanged = "CurrentItemContext";
         NSDictionary *pixBuffAttributes = @{(id)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange)};
         _videoOutput = [[AVPlayerItemVideoOutput alloc] initWithPixelBufferAttributes:pixBuffAttributes];
         [_videoOutput setDelegate:self queue:dispatch_get_main_queue()];
-        _videoOutput.suppressesPlayerRendering = YES;
+        _videoOutput.suppressesPlayerRendering = self.shouldSuppressPlayerRendering;
         
         [item addOutput:_videoOutput];
         
@@ -284,6 +284,13 @@ static char* ItemChanged = "CurrentItemContext";
 	}
 	
 	return playableDuration;
+}
+
+- (void)setShouldSuppressPlayerRendering:(BOOL)shouldSuppressPlayerRendering
+{
+    _shouldSuppressPlayerRendering = shouldSuppressPlayerRendering;
+    
+    _videoOutput.suppressesPlayerRendering = shouldSuppressPlayerRendering;
 }
 
 - (void)setItemByStringPath:(NSString *)stringPath {


### PR DESCRIPTION
In certain cases we still want SCPlayer to render video frames, if we are using methods such as face detection - which does not render entire image (alternatively we could implement this ourselves). It is much easier to enable a property called `shouldSuppressPlayerRendering`, which allows us to control this behaviour. The property is `YES` by default, because it is the current default functionality of `SCPlayer`. When set to `NO`, player will still render the video in addition to sending frames to CIImageRenderer delegate.