### PR TITLE
Added SCRecorderToolsViewDelegate protocol.

### DIFF
--- a/Library/Sources/SCRecorderToolsView.h
+++ b/Library/Sources/SCRecorderToolsView.h
@@ -16,8 +16,19 @@
 //} SCRecorderToolsViewShowFocusMode;
 
 @class SCRecorder;
+@class SCRecorderToolsView;
+
+@protocol SCRecorderToolsViewDelegate <NSObject>
+
+@optional
+
+- (void)recorderToolsView:(SCRecorderToolsView *__nonnull)recorderToolsView didTapToFocusWithGestureRecognizer:(UIGestureRecognizer *__nonnull)gestureRecognizer;
+
+@end
 
 @interface SCRecorderToolsView : UIView
+
+@property (nonatomic, weak) __nullable id<SCRecorderToolsViewDelegate> delegate;
 
 /**
  The instance of the SCRecorder to use.

--- a/Library/Sources/SCRecorderToolsView.m
+++ b/Library/Sources/SCRecorderToolsView.m
@@ -139,6 +139,11 @@ static char *ContextDidChangeDevice = "DidChangeDevice";
     CGPoint tapPoint = [gestureRecognizer locationInView:recorder.previewView];
     CGPoint convertedFocusPoint = [recorder convertToPointOfInterestFromViewCoordinates:tapPoint];
     [recorder autoFocusAtPoint:convertedFocusPoint];
+    
+    id<SCRecorderToolsViewDelegate> delegate = self.delegate;
+    if ([delegate respondsToSelector:@selector(recorderToolsView:didTapToFocusWithGestureRecognizer:)]) {
+        [delegate recorderToolsView:self didTapToFocusWithGestureRecognizer:gestureRecognizer];
+    }
 }
 
 // Change to continuous auto focus. The camera will constantly focus at the point choosen.


### PR DESCRIPTION
The first method added to this protocol, `recorderToolsView:didTapToFocusWithGestureRecognizer:`, adds a callback in the gesture recognizer handler after tap to focus is executed.  This can allow the developer to customize the animation when tap to focus is enabled (instead of using the default).