### PR TITLE
Changed CGBitmapInfo setting in video overlay render

### DIFF
--- a/Library/Sources/SCAssetExportSession.m
+++ b/Library/Sources/SCAssetExportSession.m
@@ -152,7 +152,9 @@
         }
         CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
         
-        CGContextRef ctx = CGBitmapContextCreate(CVPixelBufferGetBaseAddress(outputPixelBuffer), CVPixelBufferGetWidth(outputPixelBuffer), CVPixelBufferGetHeight(outputPixelBuffer), 8, CVPixelBufferGetBytesPerRow(outputPixelBuffer), colorSpace, (CGBitmapInfo)kCGImageAlphaPremultipliedFirst);
+        CGBitmapInfo bitmapInfo = kCGBitmapByteOrder32Little | kCGImageAlphaNoneSkipFirst;
+        
+        CGContextRef ctx = CGBitmapContextCreate(CVPixelBufferGetBaseAddress(outputPixelBuffer), CVPixelBufferGetWidth(outputPixelBuffer), CVPixelBufferGetHeight(outputPixelBuffer), 8, CVPixelBufferGetBytesPerRow(outputPixelBuffer), colorSpace, bitmapInfo);
         
         CGColorSpaceRelease(colorSpace);
         


### PR DESCRIPTION
Changed the CGBitmapInfo setting when rendering the video overlay to
ensure colors appear correct in final export.