### PR TITLE
Allow for further processing of pixel buffer prior to appending.

### DIFF
--- a/Library/Sources/CIImageRenderer.h
+++ b/Library/Sources/CIImageRenderer.h
@@ -31,6 +31,11 @@
 - (void)setImageBySampleBuffer:(__nonnull CMSampleBufferRef)sampleBuffer;
 
 /**
+ Some objects may use this property to set a pixel buffer for further processing.
+ */
+- (void)setImageByPixelBuffer:(__nonnull CVPixelBufferRef)pixelBuffer;
+
+/**
  Set the CIImage using an UIImage
  */
 - (void)setImageByUIImage:(UIImage *__nullable)image;

--- a/Library/Sources/SCRecorderDelegate.h
+++ b/Library/Sources/SCRecorderDelegate.h
@@ -95,6 +95,11 @@ typedef NS_ENUM(NSInteger, SCFlashMode) {
 - (void)recorder:(SCRecorder *__nonnull)recorder didCompleteSegment:(SCRecordSessionSegment *__nullable)segment inSession:(SCRecordSession *__nonnull)session error:(NSError *__nullable)error;
 
 /**
+ Called when the recorder will append a video buffer in a session
+ */
+- (void)recorder:(SCRecorder *__nonnull)recorder willAppendVideoSampleBuffer:(CVPixelBufferRef __nonnull)pixelBuffer inSession:(SCRecordSession *__nonnull)session;
+
+/**
  Called when the recorder has appended a video buffer in a session
  */
 - (void)recorder:(SCRecorder *__nonnull)recorder didAppendVideoSampleBufferInSession:(SCRecordSession *__nonnull)session;


### PR DESCRIPTION
Added an additional callback to the SCRecorderDelegate **recorder:willAppendVideoSampleBuffer:inSession:** which exposes the underlying pixel buffer for further processing (very useful for say creating a CGContext from it and drawing to the pixel buffer directly - i.e. drawing on the video frames in real-time). Not sure if that's the best name for a method that receives a pixel buffer, so certainly open to a better suggestion!

Also added another method to CIImageRenderer to optionally set the image with a pixel buffer, for the same reasons as above, to further process the pixel buffer and then render it on-screen.
