### PR TITLE
set nil to EAGLContext currentContext.

### DIFF
--- a/Library/Sources/SCImageView.m
+++ b/Library/Sources/SCImageView.m
@@ -49,6 +49,10 @@
     return self;
 }
 
+- (void)dealloc {
+    [EAGLContext setCurrentContext:nil];
+}
+
 - (void)_imageViewCommonInit {
     _scaleAndResizeCIImageAutomatically = YES;
     self.preferredCIImageTransform = CGAffineTransformIdentity;


### PR DESCRIPTION
the app to crash in dealloc of SCSwipeableFilterView

main thread stack
> [EAGLContext setCurrentContext:] EXC_BAD_ACCESS

http://stackoverflow.com/questions/12603161/ios-6-mkmapview-crashes-on-eaglcontext-setcurrentcontext

