### PR TITLE
add automaticallyConfiguresApplicationAudioSession

### DIFF
--- a/Library/Sources/SCRecorder.h
+++ b/Library/Sources/SCRecorder.h
@@ -111,6 +111,13 @@
 @property (copy, nonatomic) NSString *__nonnull captureSessionPreset;
 
 /**
+ The value of this property defaults to YES, causing the capture session to automatically configure the app’s shared AVAudioSession instance for optimal recording.
+ 
+ If you set this property’s value to NO, your app is responsible for selecting appropriate audio session settings. Recording may fail if the audio session’s settings are incompatible with the capture session.
+ */
+@property (assign, nonatomic) BOOL automaticallyConfiguresApplicationAudioSession;
+
+/**
  The captureSession. This will be null until prepare or startRunning has
  been called. Calling unprepare will set this property to null again.
  */

--- a/Library/Sources/SCRecorder.m
+++ b/Library/Sources/SCRecorder.m
@@ -80,8 +80,9 @@ static char* SCRecorderPhotoOptionsContext = "PhotoOptionsContext";
         _lastAudioBuffer = [SCSampleBufferHolder new];
         _maxRecordDuration = kCMTimeInvalid;
         _resetZoomOnChangeDevice = YES;
-        _mirrorOnFrontCamera = NO;
-        
+		_mirrorOnFrontCamera = NO;
+		_automaticallyConfiguresApplicationAudioSession = YES;
+		
         self.device = AVCaptureDevicePositionBack;
         _videoConfiguration = [SCVideoConfiguration new];
         _audioConfiguration = [SCAudioConfiguration new];
@@ -299,6 +300,7 @@ static char* SCRecorderPhotoOptionsContext = "PhotoOptionsContext";
     }
     
     AVCaptureSession *session = [[AVCaptureSession alloc] init];
+	session.automaticallyConfiguresApplicationAudioSession = self.automaticallyConfiguresApplicationAudioSession;
     _beginSessionConfigurationCount = 0;
     _captureSession = session;
     


### PR DESCRIPTION
Allows customized audio sessions. For example when recording a mix of
microphone and currently playing music