### PR TITLE
Fix for generating binary for App Store submission

### DIFF
--- a/Library/SCRecorder.xcodeproj/project.pbxproj
+++ b/Library/SCRecorder.xcodeproj/project.pbxproj
@@ -23,38 +23,38 @@
 		90D4FBE61BC6DDDC0017748D /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90D4FBE51BC6DDDC0017748D /* GLKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		DC10CF281ACFD458009880C4 /* SCWeakSelectorTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = DC10CF261ACFD458009880C4 /* SCWeakSelectorTarget.h */; };
 		DC10CF291ACFD458009880C4 /* SCWeakSelectorTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = DC10CF271ACFD458009880C4 /* SCWeakSelectorTarget.m */; };
-		DC1949C019C07F1600E92A95 /* SCSampleBufferHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1949BE19C07F1600E92A95 /* SCSampleBufferHolder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC1949C019C07F1600E92A95 /* SCSampleBufferHolder.h in Headers */ = {isa = PBXBuildFile; fileRef = DC1949BE19C07F1600E92A95 /* SCSampleBufferHolder.h */; };
 		DC1949C119C07F1600E92A95 /* SCSampleBufferHolder.m in Sources */ = {isa = PBXBuildFile; fileRef = DC1949BF19C07F1600E92A95 /* SCSampleBufferHolder.m */; };
-		DC23C1C71AAF95600013E14C /* SCRecordSessionSegment.h in Headers */ = {isa = PBXBuildFile; fileRef = DC23C1C51AAF95600013E14C /* SCRecordSessionSegment.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC23C1C71AAF95600013E14C /* SCRecordSessionSegment.h in Headers */ = {isa = PBXBuildFile; fileRef = DC23C1C51AAF95600013E14C /* SCRecordSessionSegment.h */; };
 		DC23C1C81AAF95600013E14C /* SCRecordSessionSegment.m in Sources */ = {isa = PBXBuildFile; fileRef = DC23C1C61AAF95600013E14C /* SCRecordSessionSegment.m */; };
 		DC23FE1217B4200800389EDA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC551C4917ADD66000E37F8F /* Foundation.framework */; };
 		DC23FE2117B4519100389EDA /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC551C6A17ADDA4400E37F8F /* AVFoundation.framework */; };
 		DC23FE2217B4519A00389EDA /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC551C4B17ADD66000E37F8F /* CoreGraphics.framework */; };
 		DC23FE2317B451A100389EDA /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC551C4717ADD66000E37F8F /* UIKit.framework */; };
-		DC4CBA4D1863118E00532F1F /* SCAudioTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DCCAB6AB17B46C8900CEA47B /* SCAudioTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC4CBA4D1863118E00532F1F /* SCAudioTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DCCAB6AB17B46C8900CEA47B /* SCAudioTools.h */; };
 		DC4CBA4E1863118E00532F1F /* SCAudioTools.m in Sources */ = {isa = PBXBuildFile; fileRef = DCCAB6AC17B46C8900CEA47B /* SCAudioTools.m */; };
-		DC4CBA511863118E00532F1F /* SCPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF6142717D14A3700341EC2 /* SCPlayer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC4CBA511863118E00532F1F /* SCPlayer.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF6142717D14A3700341EC2 /* SCPlayer.h */; };
 		DC4CBA521863118E00532F1F /* SCPlayer.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF6142817D14A3700341EC2 /* SCPlayer.m */; };
-		DC4CBA531863118E00532F1F /* SCVideoPlayerView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF6142A17D1527F00341EC2 /* SCVideoPlayerView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC4CBA531863118E00532F1F /* SCVideoPlayerView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF6142A17D1527F00341EC2 /* SCVideoPlayerView.h */; };
 		DC4CBA541863118E00532F1F /* SCVideoPlayerView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCF6142B17D1527F00341EC2 /* SCVideoPlayerView.m */; };
 		DC50285818E51FC0004E833F /* SCRecorder.m in Sources */ = {isa = PBXBuildFile; fileRef = DC50285618E4FA5E004E833F /* SCRecorder.m */; };
-		DC50285918E51FC9004E833F /* SCRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = DC50285518E4FA5E004E833F /* SCRecorder.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC50285918E51FC9004E833F /* SCRecorder.h in Headers */ = {isa = PBXBuildFile; fileRef = DC50285518E4FA5E004E833F /* SCRecorder.h */; };
 		DC50285A18E52023004E833F /* SCRecordSession.m in Sources */ = {isa = PBXBuildFile; fileRef = DC50285318E4F23F004E833F /* SCRecordSession.m */; };
-		DC633E2F192BCE0D00050796 /* SCFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DC633E25192BCE0D00050796 /* SCFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC633E2F192BCE0D00050796 /* SCFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DC633E25192BCE0D00050796 /* SCFilter.h */; };
 		DC633E30192BCE0D00050796 /* SCFilter.m in Sources */ = {isa = PBXBuildFile; fileRef = DC633E26192BCE0D00050796 /* SCFilter.m */; };
 		DC7A62BF1AFA47EC00EAB60C /* SCFilterAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = DC7A62BD1AFA47EC00EAB60C /* SCFilterAnimation.h */; };
 		DC7A62C01AFA47EC00EAB60C /* SCFilterAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7A62BE1AFA47EC00EAB60C /* SCFilterAnimation.m */; };
-		DC933E8B193814D1007E2E88 /* SCSwipeableFilterView.h in Headers */ = {isa = PBXBuildFile; fileRef = DC933E89193814D1007E2E88 /* SCSwipeableFilterView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DC933E8B193814D1007E2E88 /* SCSwipeableFilterView.h in Headers */ = {isa = PBXBuildFile; fileRef = DC933E89193814D1007E2E88 /* SCSwipeableFilterView.h */; };
 		DC933E8C193814D1007E2E88 /* SCSwipeableFilterView.m in Sources */ = {isa = PBXBuildFile; fileRef = DC933E8A193814D1007E2E88 /* SCSwipeableFilterView.m */; };
-		DCA163951A2028B800505966 /* SCVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163931A2028B800505966 /* SCVideoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCA163951A2028B800505966 /* SCVideoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163931A2028B800505966 /* SCVideoConfiguration.h */; };
 		DCA163961A2028B800505966 /* SCVideoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA163941A2028B800505966 /* SCVideoConfiguration.m */; };
-		DCA163991A2028C400505966 /* SCAudioConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163971A2028C400505966 /* SCAudioConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCA163991A2028C400505966 /* SCAudioConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163971A2028C400505966 /* SCAudioConfiguration.h */; };
 		DCA1639A1A2028C400505966 /* SCAudioConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA163981A2028C400505966 /* SCAudioConfiguration.m */; };
-		DCA1639D1A2028D100505966 /* SCMediaTypeConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA1639B1A2028D100505966 /* SCMediaTypeConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCA1639D1A2028D100505966 /* SCMediaTypeConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA1639B1A2028D100505966 /* SCMediaTypeConfiguration.h */; };
 		DCA1639E1A2028D100505966 /* SCMediaTypeConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA1639C1A2028D100505966 /* SCMediaTypeConfiguration.m */; };
-		DCA163A31A23C7C300505966 /* SCPhotoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163A11A23C7C300505966 /* SCPhotoConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCA163A31A23C7C300505966 /* SCPhotoConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA163A11A23C7C300505966 /* SCPhotoConfiguration.h */; };
 		DCA163A41A23C7C300505966 /* SCPhotoConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA163A21A23C7C300505966 /* SCPhotoConfiguration.m */; };
-		DCA836EC18FC2C910058FE13 /* SCRecorderFocusTargetView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA836EA18FC2C910058FE13 /* SCRecorderFocusTargetView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCA836EC18FC2C910058FE13 /* SCRecorderFocusTargetView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA836EA18FC2C910058FE13 /* SCRecorderFocusTargetView.h */; };
 		DCA836ED18FC2C910058FE13 /* SCRecorderFocusTargetView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCA836EB18FC2C910058FE13 /* SCRecorderFocusTargetView.m */; };
 		DCA8EF51192BD1C200839BE2 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DC3528A817B963830077F039 /* Cocoa.framework */; };
 		DCA8EF57192BD1C200839BE2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = DCA8EF55192BD1C200839BE2 /* InfoPlist.strings */; };
@@ -62,13 +62,13 @@
 		DCA8EF7D192BD21B00839BE2 /* SCFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = DC633E25192BCE0D00050796 /* SCFilter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		DCA8EF88192BD55100839BE2 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA8EF87192BD55100839BE2 /* QuartzCore.framework */; };
 		DCA8EF8E192BD73A00839BE2 /* SCRecorderMac.h in Headers */ = {isa = PBXBuildFile; fileRef = DCA8EF8D192BD71100839BE2 /* SCRecorderMac.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCB04159192458C800D945D2 /* SCImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCB04157192458C800D945D2 /* SCImageView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCB04159192458C800D945D2 /* SCImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCB04157192458C800D945D2 /* SCImageView.h */; };
 		DCB0415A192458C800D945D2 /* SCImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCB04158192458C800D945D2 /* SCImageView.m */; };
-		DCB041671924663700D945D2 /* SCAssetExportSession.h in Headers */ = {isa = PBXBuildFile; fileRef = DCB041651924663700D945D2 /* SCAssetExportSession.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCB041671924663700D945D2 /* SCAssetExportSession.h in Headers */ = {isa = PBXBuildFile; fileRef = DCB041651924663700D945D2 /* SCAssetExportSession.h */; };
 		DCB041681924663700D945D2 /* SCAssetExportSession.m in Sources */ = {isa = PBXBuildFile; fileRef = DCB041661924663700D945D2 /* SCAssetExportSession.m */; };
-		DCBA8FE61A92B2FF00DD1A79 /* SCRecorderToolsView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCBA8FE41A92B2FF00DD1A79 /* SCRecorderToolsView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCBA8FE61A92B2FF00DD1A79 /* SCRecorderToolsView.h in Headers */ = {isa = PBXBuildFile; fileRef = DCBA8FE41A92B2FF00DD1A79 /* SCRecorderToolsView.h */; };
 		DCBA8FE71A92B2FF00DD1A79 /* SCRecorderToolsView.m in Sources */ = {isa = PBXBuildFile; fileRef = DCBA8FE51A92B2FF00DD1A79 /* SCRecorderToolsView.m */; };
-		DCC1FC491A4AF1DD00F1C653 /* SCRecorderTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DCC1FC471A4AF1DD00F1C653 /* SCRecorderTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCC1FC491A4AF1DD00F1C653 /* SCRecorderTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DCC1FC471A4AF1DD00F1C653 /* SCRecorderTools.h */; };
 		DCC1FC4A1A4AF1DD00F1C653 /* SCRecorderTools.m in Sources */ = {isa = PBXBuildFile; fileRef = DCC1FC481A4AF1DD00F1C653 /* SCRecorderTools.m */; };
 		DCD12A9F1B456C5E0064674D /* SCProcessingQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = DCD12A9D1B456C5E0064674D /* SCProcessingQueue.h */; };
 		DCD12AA01B456C5E0064674D /* SCProcessingQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = DCD12A9E1B456C5E0064674D /* SCProcessingQueue.m */; };
@@ -121,7 +121,7 @@
 		DCEE378D1B17F3CA0019C7B5 /* SCContext.m in Sources */ = {isa = PBXBuildFile; fileRef = DCEE37891B17E6480019C7B5 /* SCContext.m */; };
 		DCEE378E1B17F3D50019C7B5 /* SCWeakSelectorTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = DC10CF271ACFD458009880C4 /* SCWeakSelectorTarget.m */; };
 		DCEE378F1B17F3D50019C7B5 /* SCFilterAnimation.m in Sources */ = {isa = PBXBuildFile; fileRef = DC7A62BE1AFA47EC00EAB60C /* SCFilterAnimation.m */; };
-		DCF3A68F1AB9F4760034CF5C /* SCRecorderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF3A68E1AB9F4760034CF5C /* SCRecorderDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DCF3A68F1AB9F4760034CF5C /* SCRecorderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = DCF3A68E1AB9F4760034CF5C /* SCRecorderDelegate.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -508,34 +508,34 @@
 			buildActionMask = 2147483647;
 			files = (
 				90B02E3F1BCC003D00559011 /* UIImage+SCSaveToCameraRoll.h in Headers */,
-				DCA163A31A23C7C300505966 /* SCPhotoConfiguration.h in Headers */,
 				9079317F1BD451C200D7D181 /* SCFilter+UIImage.h in Headers */,
-				DCA163991A2028C400505966 /* SCAudioConfiguration.h in Headers */,
-				DCA163951A2028B800505966 /* SCVideoConfiguration.h in Headers */,
 				90D4FBDF1BC6C1840017748D /* SCFilterImageView.h in Headers */,
 				90B02E3B1BCBFE7F00559011 /* SCSaveToCameraRollOperation.h in Headers */,
-				DC23C1C71AAF95600013E14C /* SCRecordSessionSegment.h in Headers */,
 				9079317B1BD2A06700D7D181 /* SCFilter+VideoComposition.h in Headers */,
+				DC7A62BF1AFA47EC00EAB60C /* SCFilterAnimation.h in Headers */,
+				DCA163A31A23C7C300505966 /* SCPhotoConfiguration.h in Headers */,
+				DCA163991A2028C400505966 /* SCAudioConfiguration.h in Headers */,
+				DCA163951A2028B800505966 /* SCVideoConfiguration.h in Headers */,
+				DC23C1C71AAF95600013E14C /* SCRecordSessionSegment.h in Headers */,
 				DC50285918E51FC9004E833F /* SCRecorder.h in Headers */,
 				DC4CBA531863118E00532F1F /* SCVideoPlayerView.h in Headers */,
 				DC633E2F192BCE0D00050796 /* SCFilter.h in Headers */,
 				DC933E8B193814D1007E2E88 /* SCSwipeableFilterView.h in Headers */,
 				DCA836EC18FC2C910058FE13 /* SCRecorderFocusTargetView.h in Headers */,
 				DC4CBA511863118E00532F1F /* SCPlayer.h in Headers */,
-				DC7A62BF1AFA47EC00EAB60C /* SCFilterAnimation.h in Headers */,
 				DCA1639D1A2028D100505966 /* SCMediaTypeConfiguration.h in Headers */,
 				DCF3A68F1AB9F4760034CF5C /* SCRecorderDelegate.h in Headers */,
 				DCB041671924663700D945D2 /* SCAssetExportSession.h in Headers */,
 				DCB04159192458C800D945D2 /* SCImageView.h in Headers */,
 				DCBA8FE61A92B2FF00DD1A79 /* SCRecorderToolsView.h in Headers */,
+				DCC1FC491A4AF1DD00F1C653 /* SCRecorderTools.h in Headers */,
+				DC4CBA4D1863118E00532F1F /* SCAudioTools.h in Headers */,
+				DC1949C019C07F1600E92A95 /* SCSampleBufferHolder.h in Headers */,
 				DC10CF281ACFD458009880C4 /* SCWeakSelectorTarget.h in Headers */,
 				DCEE378A1B17E6480019C7B5 /* SCContext.h in Headers */,
-				DCC1FC491A4AF1DD00F1C653 /* SCRecorderTools.h in Headers */,
 				DCD12A9F1B456C5E0064674D /* SCProcessingQueue.h in Headers */,
-				DC4CBA4D1863118E00532F1F /* SCAudioTools.h in Headers */,
 				90B02E351BC995CD00559011 /* NSURL+SCSaveToCameraRoll.h in Headers */,
 				DCD12AA41B45AA540064674D /* SCIOPixelBuffers.h in Headers */,
-				DC1949C019C07F1600E92A95 /* SCSampleBufferHolder.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Library/Sources/SCRecordSession.m
+++ b/Library/Sources/SCRecordSession.m
@@ -708,7 +708,16 @@ NSString * const SCRecordSessionDocumentDirectory = @"DocumentDirectory";
         }
         duration = computedFrameDuration;
     }
-    
+    if (videoTimeScale < 1)
+    {
+        static int counter = 0;
+        NSInteger downsampleRatio = round(1/videoTimeScale);
+        if ((counter++)%downsampleRatio != 0)
+        {
+            completion(NO);
+            return;
+        }
+    }
     //    CMTime timeVideo = _lastTimeVideo;
     //    CMTime actualBufferDuration = duration;
     //

--- a/Library/Sources/SCRecordSession.m
+++ b/Library/Sources/SCRecordSession.m
@@ -696,6 +696,11 @@ NSString * const SCRecordSessionDocumentDirectory = @"DocumentDirectory";
 }
 
 - (void)appendVideoPixelBuffer:(CVPixelBufferRef)videoPixelBuffer atTime:(CMTime)actualBufferTime duration:(CMTime)duration completion:(void (^)(BOOL))completion {
+    static int counter = 0;
+    if (CMTIME_IS_INVALID(_sessionStartTime)) {
+        counter = 0; // Start of new session
+    }
+
     [self _startSessionIfNeededAtTime:actualBufferTime];
 
     CMTime bufferTimestamp = CMTimeSubtract(actualBufferTime, _timeOffset);
@@ -710,7 +715,6 @@ NSString * const SCRecordSessionDocumentDirectory = @"DocumentDirectory";
     }
     if (videoTimeScale < 1)
     {
-        static int counter = 0;
         NSInteger downsampleRatio = round(1/videoTimeScale);
         if ((counter++)%downsampleRatio != 0)
         {

--- a/Library/Sources/SCRecorderToolsView.m
+++ b/Library/Sources/SCRecorderToolsView.m
@@ -107,6 +107,11 @@ static char *ContextDidChangeDevice = "DidChangeDevice";
     
     CGPoint viewPoint = [self.recorder convertPointOfInterestToViewCoordinates:currentFocusPoint];
     viewPoint = [self convertPoint:viewPoint fromView:self.recorder.previewView];
+
+    if (viewPoint.x != viewPoint.x || viewPoint.y != viewPoint.y) // Nan check
+    {
+        return;
+    }
     self.cameraFocusTargetView.center = viewPoint;
 }
 


### PR DESCRIPTION
Problem: We added SCRecorder as a submodule to our project. Then, we archived and generated the final binary to be submitted to App Store. However, XCode did not allow this binary to be uploaded. After some research, we found that if we move the items in SCRecorder -> Build Phases -> Headers -> Public  to Project, it works fine.

Is there any particular reason why those headers are in Public Headers? If not, it would be useful to make the pull request.
