### PR TITLE
Fix for not auto adjusting exposure/focus

### DIFF
--- a/Library/Sources/SCRecorder.m
+++ b/Library/Sources/SCRecorder.m
@@ -1140,6 +1140,8 @@ static char* SCRecorderPhotoOptionsContext = "PhotoOptionsContext";
             device.whiteBalanceMode = whiteBalanceMode;
         }
         
+        device.subjectAreaChangeMonitoringEnabled = !continuousMode;
+
         [device unlockForConfiguration];
         
         id<SCRecorderDelegate> delegate = self.delegate;


### PR DESCRIPTION
For some reason when continuousMode is set it doesn't actually update continuously. The following change seems to fix this.