### PR TITLE
Fix auto exposure and autofocus not working properly. Issue 341

### DIFF
--- a/Library/Sources/SCRecorder.m
+++ b/Library/Sources/SCRecorder.m
@@ -971,7 +971,17 @@ static char* SCRecorderPhotoOptionsContext = "PhotoOptionsContext";
                 if (newDevice.isSmoothAutoFocusSupported) {
                     newDevice.smoothAutoFocusEnabled = YES;
                 }
-                newDevice.subjectAreaChangeMonitoringEnabled = true;
+                
+                if ([newDevice isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
+                    newDevice.subjectAreaChangeMonitoringEnabled = true;
+                } else {
+                    if ([newDevice isExposureModeSupported:AVCaptureExposureModeContinuousAutoExposure]) {
+                        newDevice.exposureMode = AVCaptureExposureModeContinuousAutoExposure;
+                    }
+                    if ([newDevice isFocusModeSupported:AVCaptureFocusModeContinuousAutoFocus]) {
+                        newDevice.exposureMode = AVCaptureFocusModeContinuousAutoFocus;
+                    }
+                }
                 
                 if (newDevice.isLowLightBoostSupported) {
                     newDevice.automaticallyEnablesLowLightBoostWhenAvailable = YES;


### PR DESCRIPTION
The issue here is that when subject area change is detected, we try to do an autofocus on the centre of the image, then we wait for that focus operation to be done to put the camera back in continuous focus/exposure mode. The problem is that the front cam doesn't support that focus mode and the focus operation never completes. In fact, in `_applyPointOfInterest:continuousMode:`, `focusing` stays as `NO`. Now, if we cause the camera to get its exposure really high(by covering the lens for example) the image becomes all white, and no further subject area changes occur and we're now stuck in non-continuous mode.

The proposed fix is to disable this entire piece of logic if the camera is incapable of doing any kind of autofocus anyway. I've tested this change and it works well and I don't think it breaks anything. If it does, I'll be happy to fix it so it can be merged